### PR TITLE
v-model compatibility

### DIFF
--- a/src/Switch.vue
+++ b/src/Switch.vue
@@ -1,6 +1,12 @@
 <template>
   <label class="switch" :class="classObject">
-    <input type="checkbox" :name="name" :disabled="disabled" v-model="value">
+    <input
+      :disabled="disabled"
+      :name="name"
+      :value="value"
+      @change="handleChange"
+      type="checkbox"
+    >
   </label>
 </template>
 
@@ -12,21 +18,8 @@ export default {
     type: String,
     size: String,
     checked: Boolean,
-    name: String
-  },
-
-  data () {
-    return {
-      value: null
-    }
-  },
-
-  beforeMount () {
-    this.value = this.checked
-  },
-
-  mounted () {
-    this.$emit('input', this.value = !!this.checked)
+    name: String,
+    value: Boolean
   },
 
   computed: {
@@ -40,9 +33,9 @@ export default {
     }
   },
 
-  watch: {
-    value (val) {
-      this.$emit('input', val)
+  methods: {
+    handleChange (event) {
+      this.$emit('input', event.target.checked)
     }
   }
 }


### PR DESCRIPTION
I've changed the code to make it compatible to v-model.
This way the value can be passed down from the parent.

This explains how `v-model` works using vuejs:
https://vuejs.org/v2/guide/components.html#Form-Input-Components-using-Custom-Events

This way it can be updated from other outside events, such as real time connections.

Here is a demonstration how it can work afterwards. Note that they all show the same data.
![vue-bulma-switch-realtime](https://cloud.githubusercontent.com/assets/449438/25610642/527bfcc6-2f24-11e7-8718-f1fdf3ded9c4.gif)
